### PR TITLE
Add libffi dep for building on ARM

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,6 +10,7 @@ RUN mkdir /etc/letsencrypt && \
 # Install build deps
 RUN apk update && apk upgrade && apk add \
     build-base     \
+    libffi-dev     \
     python3-dev    \
     py3-pip        \
     clang          \


### PR DESCRIPTION
docker-compose up fails on ARM computers without this addition. Something in PIP/python requires this additional package.